### PR TITLE
Support wildcard hostnames in certificates

### DIFF
--- a/src/grisp_seawater_http.erl
+++ b/src/grisp_seawater_http.erl
@@ -68,6 +68,9 @@ ssl_opts(ServerName) ->
                 {depth, 99},
                 {cacerts, certifi:cacerts() ++ server_chain(ServerName)},
                 {cert, ClientChain},
+                {customize_hostname_check, [
+                    {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+                ]},
                 {key, #{
                     algorithm => ecdsa,
                     sign_fun => {grisp_cryptoauth, sign_fun}


### PR DESCRIPTION
Successfully accepts `seawater.stritzinger.com` as well as `*.fly.io`