### PR TITLE
Fix WS disconnection handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Such client is disabled by default (`{ntp, false}`), and is not required to auth
 Accepts an integer that represents time in milliseconds, default value is `5_000`.
 Allows to tweak the timeout of each API request going through the websocket.
 
+### ws_ping_timeout
+Accepts an integer that represents time in milliseconds, default value is `60_000`.
+Allows to tweak the timeout between expected ping frames from the server.
+If the timeout is exceeded, the socket is closed and a new connection is attempted.
+
 ### logs_interval
 
 Accepts an integer that represents time in milliseconds, default value is `2_000`.

--- a/src/grisp_connect.app.src
+++ b/src/grisp_connect.app.src
@@ -22,6 +22,7 @@
         {connect, true}, % keeps a constant connection with grisp.io
         {ntp, false}, % if set to true, starts the NTP client
         {ws_requests_timeout, 5_000},
+        {ws_ping_timeout, 60_000},
         {logs_interval, 2_000},
         {logs_batch_size, 100},
         {logger, [

--- a/src/grisp_connect_log_server.erl
+++ b/src/grisp_connect_log_server.erl
@@ -111,6 +111,6 @@ jsonify_meta(#{meta := Meta} = Event) ->
 
 is_json_compatible(Term) ->
     try jsx:is_term(Term)
-    catch error:_:_ ->
+    catch error:_ ->
         false
     end.

--- a/src/grisp_connect_log_server.erl
+++ b/src/grisp_connect_log_server.erl
@@ -78,7 +78,7 @@ jsonify(Event) ->
 jsonify_msg(#{msg := {string, String}} = Event) ->
     maps:put(msg, unicode:characters_to_binary(String), Event);
 jsonify_msg(#{msg := {report, Report}} = Event) ->
-    case jsx:is_term(Report) of
+    case is_json_compatible(Report) of
         true ->
             maps:put(msg, Report, Event);
         false ->
@@ -108,3 +108,9 @@ jsonify_meta(#{meta := Meta} = Event) ->
     Optional = maps:without(maps:keys(Default), Meta),
     FilterFun = fun(Key, Value) -> jsx:is_term(#{Key => Value}) end,
     maps:put(meta, maps:merge(maps:filter(FilterFun, Optional), Default), Event).
+
+is_json_compatible(Term) ->
+    try jsx:is_term(Term)
+    catch error:_:_ ->
+        false
+    end.

--- a/src/grisp_connect_ws.erl
+++ b/src/grisp_connect_ws.erl
@@ -78,8 +78,9 @@ handle_info({gun_up, GunPid, _}, #state{gun_pid = GunPid} = S) ->
                               #{silence_pings => false}),
     NewState = S#state{gun_pid = GunPid, gun_ref = GunRef, ws_stream = WsStream},
     {noreply, NewState};
-handle_info({gun_up, _OldPid, http}, #state{gun_pid = _GunPid} = S) ->
-    % Ignoring outdated gun_up messages
+handle_info({gun_up, Pid, http}, #state{gun_pid = GunPid} = S) ->
+    ?LOG_WARNING("Ignoring unexpected gun_up http message"
+                 " from pid ~p, current pid is ~p", [Pid, GunPid]),
     {noreply, S};
 handle_info({gun_upgrade, Pid, Stream, [<<"websocket">>], _},
             #state{gun_pid = Pid, ws_stream = Stream} = S) ->

--- a/src/grisp_connect_ws.erl
+++ b/src/grisp_connect_ws.erl
@@ -23,7 +23,8 @@
 }).
 
 -define(disconnected_state,
-        #state{gun_pid = undefined, gun_ref = undefine, ws_up = false}).
+        #state{gun_pid = undefined, gun_ref = undefine,
+               ws_up = false, ping_timer = undefined}).
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -118,7 +119,7 @@ handle_info(M, S) ->
 % internal functions -----------------------------------------------------------
 
 shutdown_gun(#state{gun_pid = Pid, gun_ref = GunRef,
-             ping_timer = PingTimer} = State) ->
+                    ping_timer = PingTimer} = State) ->
     timer:cancel(PingTimer),
     demonitor(GunRef),
     gun:shutdown(Pid),

--- a/test/grisp_connect_api_SUITE.erl
+++ b/test/grisp_connect_api_SUITE.erl
@@ -72,7 +72,7 @@ link_device_test(_) ->
     ?assertMatch({ok, <<"pong">>}, grisp_connect:ping()).
 
 reconnect_on_gun_crash_test(_) ->
-    {state, GunPid, _, _, _} = sys:get_state(grisp_connect_ws),
+    {state, GunPid, _, _, _, _} = sys:get_state(grisp_connect_ws),
     proc_lib:stop(GunPid),
     ?assertMatch(ok, wait_disconnection()),
     ?assertMatch(ok, wait_connection()).

--- a/test/grisp_connect_log_SUITE.erl
+++ b/test/grisp_connect_log_SUITE.erl
@@ -28,7 +28,8 @@ init_per_suite(Config) ->
     ?assertEqual(ok, file:write_file(PolicyFile, <<>>)),
     application:set_env(seabac, policy_file, PolicyFile),
 
-    Config2 = grisp_connect_manager:start(CertDir, Config),
+    Config2 = grisp_connect_manager:start(Config),
+    grisp_connect_manager:kraft_start(CertDir),
     grisp_connect_manager:link_device(),
     [{cert_dir, CertDir} | Config2].
 

--- a/test/grisp_connect_manager.erl
+++ b/test/grisp_connect_manager.erl
@@ -18,6 +18,12 @@ start(CertDir, Config) ->
     application:start(mnesia),
 
     {ok, Started2} = application:ensure_all_started(kraft),
+    KraftRef = kraft_start(CertDir),
+
+    {ok, Started3} = application:ensure_all_started(grisp_manager),
+    [{apps, Started1 ++ Started2 ++ Started3}, {kraft_instance , KraftRef} | Config].
+
+kraft_start(CertDir) ->
     SslOpts = [
         {verify, verify_peer},
         {keyfile, filename:join(CertDir, "server.key")},
@@ -33,10 +39,7 @@ start(CertDir, Config) ->
         {"/grisp-connect/ws",
             {ws, grisp_manager_device_api}, #{}, #{type => json_rpc}}
     ],
-    kraft:start(KraftOpts, KraftRoutes),
-
-    {ok, Started3} = application:ensure_all_started(grisp_manager),
-    [{apps, Started1 ++ Started2 ++ Started3} | Config].
+    kraft:start(KraftOpts, KraftRoutes).
 
 cleanup_apps(Apps) ->
     mnesia:delete_table(eresu_user),

--- a/test/grisp_connect_manager.erl
+++ b/test/grisp_connect_manager.erl
@@ -5,7 +5,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 
-start(CertDir, Config) ->
+start(Config) ->
     PrivDir = ?config(priv_dir, Config),
     application:set_env(mnesia, dir, PrivDir),
 
@@ -18,23 +18,27 @@ start(CertDir, Config) ->
     application:start(mnesia),
 
     {ok, Started2} = application:ensure_all_started(kraft),
-    KraftRef = kraft_start(CertDir),
 
     {ok, Started3} = application:ensure_all_started(grisp_manager),
-    [{apps, Started1 ++ Started2 ++ Started3}, {kraft_instance , KraftRef} | Config].
+    Apps = Started1 ++ Started2 ++ Started3,
+    [{apps, Apps} | Config].
 
 kraft_start(CertDir) ->
+    kraft_start(CertDir, #{}).
+
+kraft_start(CertDir, OverrideOpts) ->
     SslOpts = [
         {verify, verify_peer},
         {keyfile, filename:join(CertDir, "server.key")},
         {certfile, filename:join(CertDir, "server.crt")},
         {cacertfile, filename:join(CertDir, "CA.crt")}
     ],
-    KraftOpts = #{
+    Opts = #{
         port => 3030,
         ssl_opts => SslOpts,
         app => grisp_manager
     },
+    KraftOpts = mapz:deep_merge(Opts, OverrideOpts),
     KraftRoutes = [
         {"/grisp-connect/ws",
             {ws, grisp_manager_device_api}, #{}, #{type => json_rpc}}

--- a/test/grisp_connect_test_client.erl
+++ b/test/grisp_connect_test_client.erl
@@ -6,10 +6,12 @@
 -export([cert_dir/0]).
 -export([serial_number/0]).
 -export([wait_connection/0]).
+-export([wait_connection/1]).
+-export([wait_disconnection/0]).
 
 %--- API -----------------------------------------------------------------------
 
-cert_dir() -> filename:join(code:lib_dir(grisp_connect, test), "certs"). 
+cert_dir() -> filename:join(code:lib_dir(grisp_connect, test), "certs").
 
 serial_number() -> <<"0000">>.
 
@@ -17,7 +19,7 @@ wait_connection() ->
     wait_connection(20).
 
 wait_connection(0) ->
-    ct:pal("grisp_connect state:~n~p~n", [sys:get_state(grisp_connect_client)]),
+    ct:pal("grisp_connect_ws state:~n~p~n", [sys:get_state(grisp_connect_ws)]),
     {error, timeout};
 wait_connection(N) ->
     case grisp_connect:is_connected() of
@@ -25,4 +27,18 @@ wait_connection(N) ->
        false ->
            ct:sleep(100),
            wait_connection(N - 1)
+    end.
+
+wait_disconnection() ->
+    wait_disconnection(20).
+
+wait_disconnection(0) ->
+    ct:pal("grisp_connect_ws state:~n~p~n", [sys:get_state(grisp_connect_ws)]),
+    {error, timeout};
+wait_disconnection(N) ->
+    case grisp_connect:is_connected() of
+        true ->
+            ct:sleep(100),
+            wait_disconnection(N - 1);
+        false -> ok
     end.

--- a/test/grisp_connect_test_client.erl
+++ b/test/grisp_connect_test_client.erl
@@ -8,6 +8,7 @@
 -export([wait_connection/0]).
 -export([wait_connection/1]).
 -export([wait_disconnection/0]).
+-export([wait_disconnection/1]).
 
 %--- API -----------------------------------------------------------------------
 


### PR DESCRIPTION
The following reconnections scenarios are handled in this PR

- [x] The server closes the connection, gun_down is handled correctly
- [x] The gun process crashes, the monitor message is used to react to it
- [x] Ping timeout, if the server is not pinging, the client throws away the connections and re-attempts it.

This PR requires https://github.com/stritzinger/kraft/pull/3 to go in production