### PR TITLE
Handle 'close' frames and 'normal' gun_down messages

### DIFF
--- a/src/grisp_connect_ws.erl
+++ b/src/grisp_connect_ws.erl
@@ -99,9 +99,9 @@ handle_info({gun_ws, Pid, Stream, {text, Text}},
             #state{gun_pid = Pid, ws_stream = Stream} = S) ->
     grisp_connect_client:handle_message(Text),
     {noreply, S};
-handle_info({gun_ws, Pid, Stream, {close, 1011, Message}},
+handle_info({gun_ws, Pid, Stream, {close, Code, Message}},
             #state{gun_pid = Pid, ws_stream = Stream} = S) ->
-    ?LOG_WARNING(#{event => stream_closed, reason => Message}),
+    ?LOG_WARNING(#{event => stream_closed, code => Code, reason => Message}),
     {noreply, S};
 handle_info({gun_down, Pid, ws, closed, [Stream]}, #state{gun_pid = Pid, ws_stream = Stream} = S) ->
     ?LOG_WARNING(#{event => ws_closed}),

--- a/src/grisp_connect_ws.erl
+++ b/src/grisp_connect_ws.erl
@@ -99,8 +99,15 @@ handle_info({gun_ws, Pid, Stream, {text, Text}},
             #state{gun_pid = Pid, ws_stream = Stream} = S) ->
     grisp_connect_client:handle_message(Text),
     {noreply, S};
+handle_info({gun_ws, Pid, Stream, {close, 1011, Message}},
+            #state{gun_pid = Pid, ws_stream = Stream} = S) ->
+    ?LOG_WARNING(#{event => stream_closed, reason => Message}),
+    {noreply, S};
 handle_info({gun_down, Pid, ws, closed, [Stream]}, #state{gun_pid = Pid, ws_stream = Stream} = S) ->
     ?LOG_WARNING(#{event => ws_closed}),
+    grisp_connect_client:disconnected(),
+    {noreply, shutdown_gun(S)};
+handle_info({gun_down, Pid, ws, normal, _}, #state{gun_pid = Pid} = S) ->
     grisp_connect_client:disconnected(),
     {noreply, shutdown_gun(S)};
 handle_info({'DOWN', _, process, Pid, Reason}, #state{gun_pid = Pid,

--- a/src/grisp_connect_ws.erl
+++ b/src/grisp_connect_ws.erl
@@ -108,6 +108,7 @@ handle_info({gun_down, Pid, ws, closed, [Stream]}, #state{gun_pid = Pid, ws_stre
     grisp_connect_client:disconnected(),
     {noreply, shutdown_gun(S)};
 handle_info({gun_down, Pid, ws, normal, _}, #state{gun_pid = Pid} = S) ->
+    ?LOG_INFO(#{event => ws_closed, reason => normal}),
     grisp_connect_client:disconnected(),
     {noreply, shutdown_gun(S)};
 handle_info({'DOWN', _, process, Pid, Reason}, #state{gun_pid = Pid,


### PR DESCRIPTION
Our backend can send `close` frames like `{close, 1011, <<"timeout waiting for pong">>}`
And in general cowboy can send various codes with empty messages.

Gun handles these messages so we only need to log and react later to a `normal` exit.