### PR TITLE
Support TLS opts for OTP >= 27

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -47,12 +47,12 @@
 {profiles, [
     {grisp, [
         {deps, [
-            {grisp_cryptoauth, "2.2.0"}
+            {grisp_cryptoauth, "2.3.0"}
         ]}
     ]},
     {prod, [
         {deps, [
-            {grisp_cryptoauth, "2.2.0"}
+            {grisp_cryptoauth, "2.3.0"}
         ]}
     ]},
     {test, [


### PR DESCRIPTION
This change keeps the old legacy otpions active for all OTP versions < 27

- [x] Merge https://github.com/grisp/grisp_cryptoauth/pull/6
- [x] Release grisp_cryptoauth
- [x] Generate prebuilts for OTP 27 and latest libs
- [x] Upgrade grisp_cryptoauth