### PR TITLE
SEA-298 Extend protocol to update sw (with grisp_updater)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # grisp_connect
 
-GRiSP.io Client Library for GRiSP
+GRiSP.io Client Library for GRiSP. This library enables secure communication
+ between your GRiSP2 board and the [GRiSP.io](https://grisp.io) services using
+ Mutual TLS (mTLS). To get started, add this application as a dependency in your
+ GRiSP2 project.
+
+⚠️ **Note:** If you plan to use the API calls related to `grisp_updater`, make
+ sure to add `grisp_updater` as a dependency in your project as well.
 
 ## Table of content
 
@@ -27,10 +33,6 @@ GRiSP.io Client Library for GRiSP
     - [Local Development](#local-development)
     - [Development on GRiSP Hardware](#development-on-grisp-hardware)
     - [Production on GRiSP Hardware](#production-on-grisp-hardware)
-
-
-Add this application as a dependency in your GRiSP2 project.
-Your board will connect securely using mTLS to the [GRiSP.io](https://grisp.io) services.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ GRiSP.io Client Library for GRiSP. This library enables secure communication
  Mutual TLS (mTLS). To get started, add this application as a dependency in your
  GRiSP2 project.
 
-⚠️ **Note:** If you plan to use the API calls related to `grisp_updater`, make
- sure to add `grisp_updater` as a dependency in your project as well.
+⚠️ **Note:** If you plan to use the API calls related to `grisp_updater_grisp2`,
+make sure to add `grisp_updater_grisp2` as a dependency in your project as well.
 
 ## Table of content
 

--- a/docs/grisp_connect_api.md
+++ b/docs/grisp_connect_api.md
@@ -28,24 +28,10 @@ We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
 
 **`error`**:
 
-| Error Content                                            | When it Happens                                   |
-| -------------------------------------------------------- | ------------------------------------------------- |
-| `{code: -10, message: "grisp_updater unavailable"}`      | Grisp updater app is not running                  |
-| `{code: -11, message: "already updating "}`              | An update is already happening                    |
-
-</p>
-</details>
-
-<details><summary><i>Post - Flash </i></summary>
-<p>
-
-**`params`:**
-| key (required *)    | value    | description                       |
-| ------------------- | -------- | --------------------------------- |
-| `"led"` *           | integer  | Number that identifies the LED, to obtain more information about the options, you can visit [grisp_led:color/2](https://hexdocs.pm/grisp/)    |
-| `"color"`           | string   | Color of the LED, by default: red. To obtain more information about the options, you can visit [grisp_led:color/2](https://hexdocs.pm/grisp/)   |
-
-**`result`**:  `"ok"`
+| Error Content                                       | When it Happens                  |
+| ----------------------------------------------------| -------------------------------- |
+| `{code: -10, message: "grisp_updater unavailable"}` | Grisp updater app is not running |
+| `{code: -11, message: "already updating "}`         | An update is already happening   |
 
 </p>
 </details>

--- a/docs/grisp_connect_api.md
+++ b/docs/grisp_connect_api.md
@@ -21,6 +21,8 @@ We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
 <details><summary><i>Post - Start an update</i></summary>
 <p>
 
+Triggers grisp_updater to install an update from the given URL.
+
 **`params`:**
 | key (required *)  | value    | description                |
 | ----------------- | -------- | -------------------------- |
@@ -33,8 +35,33 @@ We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
 
 | Error Content                                       | When it Happens                  |
 | ----------------------------------------------------| -------------------------------- |
-| `{code: -10, message: "grisp_updater unavailable"}` | Grisp updater app is not running |
-| `{code: -11, message: "already updating "}`         | An update is already happening   |
+| `{code: -10, message: "grisp_updater_unavailable"}` | Grisp updater app is not running |
+| `{code: -11, message: "already_updating"}`         | An update is already happening   |
+| `{code: -12, message: "boot_system_not_validated"}` | The board rebooted after an update and needs validation |
+
+</p>
+</details>
+
+<details><summary><i>Post - Validate an update</i></summary>
+<p>
+
+Validates the current booted partition. This can only be done after an update was installed and a reboot occurred.
+This request sets the current partition as permanent in the bootloader if it is not.
+If the new partition is not validated, from the next reboot, the bootloader will load the previous one.
+This should only be called if the new software is functioning as expected.
+
+**`params`:**
+| key (required *)  | value    | description                |
+| ----------------- | -------- | -------------------------- |
+| `"type"` *        | string   | `"validate"`               |
+
+**`result`**:  `"ok"`
+
+**`error`**:
+
+| Error Content                                       | When it Happens                  |
+| ----------------------------------------------------| -------------------------------- |
+| `{code: -13, message: "validate_from_unbooted", data: 0}` | The current partition N cannot be validated |
 
 </p>
 </details>

--- a/docs/grisp_connect_api.md
+++ b/docs/grisp_connect_api.md
@@ -36,7 +36,7 @@ Triggers grisp_updater to install an update from the given URL.
 | Error Content                                       | When it Happens                  |
 | ----------------------------------------------------| -------------------------------- |
 | `{code: -10, message: "grisp_updater_unavailable"}` | Grisp updater app is not running |
-| `{code: -11, message: "already_updating"}`         | An update is already happening   |
+| `{code: -11, message: "already_updating"}`          | An update is already happening   |
 | `{code: -12, message: "boot_system_not_validated"}` | The board rebooted after an update and needs validation |
 
 </p>
@@ -76,7 +76,7 @@ This should only be called if the new software is functioning as expected.
 |---------------|---------------------------------------------|----------|--------------------------------------|
 |`"type"`       | `"software_update_event"`                   | required |                                      |
 |`"event_type"` | `"progress"` `"warning"` `"error"` `"done"` | required |                                      |
-|`"message"`    |  integer                                    | optional | expected in case of warning          |
+|`"message"`    |  integer                                    | optional | expected in case of warning or error |
 |`"reason"`     |  integer                                    | optional | expected in case of warning or error |
 |`"percentage"` |  integer                                    | optional | expected in case of progress or error|
 

--- a/docs/grisp_connect_api.md
+++ b/docs/grisp_connect_api.md
@@ -1,0 +1,72 @@
+# UI Websocket API
+
+**Table Of Contents**
+- [UI Websocket API](#ui-websocket-api)
+  - [Backend API](#backend-api)
+    - [Requests](#requests)
+  - [Error Codes](#error-codes)
+    - [Default error codes](#default-error-codes)
+    - [Custom error codes](#custom-error-codes)
+
+We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
+
+## Backend API
+
+### Requests
+
+<details><summary><i>Post - Start an update</i></summary>
+<p>
+
+**`params`:**
+| key (required *)  | value    | description                |
+| ----------------- | -------- | -------------------------- |
+| `"type"` *        | string   | `"start_update"`           |
+| `"url"` *         | [string] | URL to the code repository |
+
+**`result`**:  `"ok"`
+
+**`error`**:
+
+| Error Content                                            | When it Happens                                   |
+| -------------------------------------------------------- | ------------------------------------------------- |
+| `{code: -32001, message: "grisp_updater unavailable"}`   | When the grisp_updater application is not running |
+
+</p>
+</details>
+
+<details><summary><i>Post - Flash </i></summary>
+<p>
+
+**`params`:**
+| key (required *)    | value    | description                       |
+| ------------------- | -------- | --------------------------------- |
+| `"led"` *           | integer  | Number that identifies the LED, to obtain more information about the options, you can visit [grisp_led:color/2](https://hexdocs.pm/grisp/)    |
+| `"color"`           | string   | Color of the LED, by default: red. To obtain more information about the options, you can visit [grisp_led:color/2](https://hexdocs.pm/grisp/)   |
+
+**`result`**:  `"ok"`
+
+</p>
+</details>
+
+## Error Codes
+
+### Default error codes
+
+|  code   |   message        | meaning                                          |
+|---------|------------------|--------------------------------------------------|
+|-32700   | Parse error      | Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text. |
+|-32600   | Invalid Request  | The JSON sent is not a valid Request object. |
+|-32601   | Method not found | The method does not exist / is not available.|
+|-32602   | Invalid params   | Invalid method parameter(s). |
+|-32603   | Internal error   | Internal JSON-RPC error. |
+
+### Custom error codes
+
+Additionally to the default jsonrpc error codes the following codes will be returned.
+
+|code  | message            | meaning |
+|---|---|---|
+| -1    | `"device not linked"`     | device can't be used without being linked to a registered user    |
+| -2    | `"token expired"`         | token is expired                          |
+| -3    | `"device already linked"` | device needs to be unlinked first via UI  |
+| -4    | `"invalid token"`         | token is e.g. not orderly encoded         |

--- a/docs/grisp_connect_api.md
+++ b/docs/grisp_connect_api.md
@@ -4,12 +4,15 @@
 - [UI Websocket API](#ui-websocket-api)
   - [Backend API](#backend-api)
     - [Requests](#requests)
+    - [Notifications](#notifications)
   - [Error Codes](#error-codes)
     - [Default error codes](#default-error-codes)
     - [Custom error codes](#custom-error-codes)
-  - [Notifications](#notifications)
 
 We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
+
+⚠️ **Note:** If you plan to use the API calls related to `grisp_updater`, make
+ sure to add `grisp_updater_grisp2` as a dependency in your project as well.
 
 ## Backend API
 
@@ -36,6 +39,23 @@ We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
 </p>
 </details>
 
+### Notifications
+
+<details><summary><code>update</code> <code>{"type":"software_update_event"}</code> - notify the current progess of grisp_updater </summary>
+<p>
+
+**`params`:**
+| key           | value                                       | type     | description                          |
+|---------------|---------------------------------------------|----------|--------------------------------------|
+|`"type"`       | `"software_update_event"`                   | required |                                      |
+|`"event_type"` | `"progress"` `"warning"` `"error"` `"done"` | required |                                      |
+|`"message"`    |  integer                                    | optional | expected in case of warning          |
+|`"reason"`     |  integer                                    | optional | expected in case of warning or error |
+|`"percentage"` |  integer                                    | optional | expected in case of progress or error|
+
+</p>
+</details>
+
 ## Error Codes
 
 ### Default error codes
@@ -58,14 +78,3 @@ Additionally to the default jsonrpc error codes the following codes will be retu
 | -2    | `"token expired"`         | token is expired                          |
 | -3    | `"device already linked"` | device needs to be unlinked first via UI  |
 | -4    | `"invalid token"`         | token is e.g. not orderly encoded         |
-
-## Notifications
-
-<details><summary><i>Notify - Status Update </i></summary>
-
-**`result`**:  `JSON Object`
-
-| key            | value             | description                       |
-| -------------- | ----------------- | --------------------------------- |
-| `"type"`       | `"status_update"` | Type of notification              |
-| `"percentage"` | integer           | Progress percentage of the update |

--- a/docs/grisp_connect_api.md
+++ b/docs/grisp_connect_api.md
@@ -18,6 +18,44 @@ We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
 
 ### Requests
 
+</p>
+</details>
+<details><summary><i>Get - partition_state</i></summary>
+<p>
+
+Retrieves the current state of the system’s partition, indicating whether the
+system requires a reboot, needs validation, or is running an old partition
+with no updates pending. This can be used to check if the system is running a
+ valid system, or has an update pending.
+
+**`params`:**
+| key (required *)  | value    | description         |
+| ----------------- | -------- | ------------------- |
+| `"type"` *        | string   | `"partition_state"` |
+
+**`result`**:  JSON Object
+
+| key             | value     | type     | description                                        |
+|-----------------|-----------|----------|----------------------------------------------------|
+| state           | string    | required | `"old"`, `"old_no_update"`, `"new"`, `"unknown"`   |
+| message         | string    | required | Message describing the current state of the system |
+| action_required | boolean   | required | Indicates whether any action is required (e.g., reboot, validation). |
+
+Meaning of the state:
+
+| key               | description                                                                                |
+|-------------------|--------------------------------------------------------------------------------------------|
+| `"new"`           | The system has booted into a new partition. Validation is required to finalize the update. |
+| `"old"`           | Current partition is old. A reboot is required to load the new partition.                  |
+| `"old_no_update"` | There is no update pending. The system is running the old partition.                       |
+| `"unknown"`       | The current partition state does not match any of the previous described states.           |
+
+**`error`**:
+
+| Error Content                                       | When it Happens                        |
+| ----------------------------------------------------| -------------------------------------- |
+| `{code: -10, message: "grisp_updater_unavailable"}` | Grisp updater app is not running       |
+
 <details><summary><i>Post - Start an update</i></summary>
 <p>
 

--- a/docs/grisp_connect_api.md
+++ b/docs/grisp_connect_api.md
@@ -7,6 +7,7 @@
   - [Error Codes](#error-codes)
     - [Default error codes](#default-error-codes)
     - [Custom error codes](#custom-error-codes)
+  - [Notifications](#notifications)
 
 We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
 
@@ -71,3 +72,14 @@ Additionally to the default jsonrpc error codes the following codes will be retu
 | -2    | `"token expired"`         | token is expired                          |
 | -3    | `"device already linked"` | device needs to be unlinked first via UI  |
 | -4    | `"invalid token"`         | token is e.g. not orderly encoded         |
+
+## Notifications
+
+<details><summary><i>Notify - Status Update </i></summary>
+
+**`result`**:  `JSON Object`
+
+| key            | value             | description                       |
+| -------------- | ----------------- | --------------------------------- |
+| `"type"`       | `"status_update"` | Type of notification              |
+| `"percentage"` | integer           | Progress percentage of the update |

--- a/docs/grisp_connect_api.md
+++ b/docs/grisp_connect_api.md
@@ -29,7 +29,8 @@ We use [jsonrpc](https://www.jsonrpc.org) 2.0 between frontend and backend.
 
 | Error Content                                            | When it Happens                                   |
 | -------------------------------------------------------- | ------------------------------------------------- |
-| `{code: -32001, message: "grisp_updater unavailable"}`   | When the grisp_updater application is not running |
+| `{code: -10, message: "grisp_updater unavailable"}`      | Grisp updater app is not running                  |
+| `{code: -11, message: "already updating "}`              | An update is already happening                    |
 
 </p>
 </details>

--- a/src/grisp_connect_api.erl
+++ b/src/grisp_connect_api.erl
@@ -203,10 +203,6 @@ error_atom(-1)  -> device_not_linked;
 error_atom(-2)  -> token_expired;
 error_atom(-3)  -> device_already_linked;
 error_atom(-4)  -> invalid_token;
-error_atom(-10) -> grisp_updater_unavailable;
-error_atom(-11) -> already_updating;
-error_atom(-12) -> boot_system_not_validated;
-error_atom(-13) -> validate_from_unbooted;
 error_atom(_)   -> jsonrpc_error.
 
 id() ->

--- a/src/grisp_connect_api.erl
+++ b/src/grisp_connect_api.erl
@@ -23,8 +23,8 @@ request(Method, Type, Params) ->
 % In case it was a response, returns the parsed ID and content to be handled by
 % the caller.
 -spec handle_msg(JSON :: binary()) ->
-    {request, Response :: binary()} |
-    {response, ID :: binary(), {ok, Result :: map()} | {error, atom()}}.
+    {send_response, Response :: binary()} |
+    {handle_response, ID :: binary(), {ok, Result :: map()} | {error, atom()}}.
 handle_msg(JSON) ->
     JSON_RPC = grisp_connect_jsonrpc:decode(JSON),
     handle_jsonrpc(JSON_RPC).
@@ -62,12 +62,12 @@ handle_request(<<"post">>, #{type := <<"start_update">>} = Params, ID) ->
         ok ->
             {result, ok, ID}
     end,
-    {request, grisp_connect_jsonrpc:encode(Reply)};
+    {send_response, grisp_connect_jsonrpc:encode(Reply)};
 handle_request(<<"post">>, #{type := <<"flash">>} = Params, ID) ->
     Led = maps:get(led, Params, 1),
     Color = maps:get(color, Params, red),
     Reply = {result, flash(Led, Color), ID},
-    {request,  grisp_connect_jsonrpc:encode(Reply)};
+    {send_response,  grisp_connect_jsonrpc:encode(Reply)};
 handle_request(_, _, ID) ->
     Error = {internal_error, method_not_found, ID},
     FormattedError = grisp_connect_jsonrpc:format_error(),
@@ -80,7 +80,7 @@ handle_response(Response) ->
         {error, Code, _Message, _Data, ID0} ->
             {ID0, {error, error_atom(Code)}}
     end,
-    {response, ID, Reply}.
+    {handle_response, ID, Reply}.
 
 flash(Led, Color) ->
     spawn(fun() ->

--- a/src/grisp_connect_api.erl
+++ b/src/grisp_connect_api.erl
@@ -12,7 +12,6 @@
 -define(method_post, <<"post">>).
 -define(method_patch, <<"patch">>).
 -define(method_delete, <<"delete">>).
--define(method_notify, <<"notify">>).
 
 %--- API -----------------------------------------------------------------------
 
@@ -87,17 +86,6 @@ handle_request(?method_post, #{type := <<"start_update">>} = Params, ID) ->
              grisp_connect_jsonrpc:format_error(
                 {internal_error, invalid_params, ID})}
         end;
-handle_request(?method_notify, #{type := <<"status_update">>} = Params, ID) ->
-    Percentage = maps:get(percentage, Params, undefined),
-    Reply = case Percentage of
-                Per when is_integer(Per) ->
-                    {result, #{percentage => Percentage}, ID};
-                undefined ->
-                    Reason       = update_percentage_not_retrieved,
-                    ReasonBinary = iolist_to_binary(io_lib:format("~p", [Reason])),
-                    grisp_connect_jsonrpc:format_error({internal_error, ReasonBinary, ID})
-            end,
-    {send_response,  grisp_connect_jsonrpc:encode(Reply)};
 handle_request(_, _, ID) ->
     Error = {internal_error, method_not_found, ID},
     FormattedError = grisp_connect_jsonrpc:format_error(Error),

--- a/src/grisp_connect_api.erl
+++ b/src/grisp_connect_api.erl
@@ -108,7 +108,7 @@ flash(Led, Color) ->
 start_update(URL) ->
     case is_running(grisp_updater) of
         true -> grisp_updater:start(URL,
-                                    grisp_conntect_updater_progress,
+                                    grisp_connect_updater_progress,
                                     #{client => self()}, #{});
         false -> {error, grisp_updater_unavailable}
     end.

--- a/src/grisp_connect_api.erl
+++ b/src/grisp_connect_api.erl
@@ -57,11 +57,6 @@ handle_rpc_messages([{internal_error, _, _} = E | Batch], Replies) ->
     handle_rpc_messages(Batch,
                         [grisp_connect_jsonrpc:format_error(E)| Replies]).
 
-handle_request(?method_post, #{type := <<"flash">>} = Params, ID) ->
-    Led = maps:get(led, Params, 1),
-    Color = maps:get(color, Params, red),
-    Reply = {result, flash(Led, Color), ID},
-    {send_response,  grisp_connect_jsonrpc:encode(Reply)};
 handle_request(?method_post, #{type := <<"start_update">>} = Params, ID) ->
     try
         URL = maps:get(url, Params),
@@ -107,15 +102,6 @@ handle_response(Response) ->
             {ID0, {error, error_atom(Code)}}
     end,
     {handle_response, ID, Reply}.
-
-flash(Led, Color) ->
-    spawn(fun() ->
-        ?LOG_NOTICE("Flash from Seawater!~n"),
-        grisp_led:color(Led, Color),
-        timer:sleep(100),
-        grisp_led:off(Led)
-    end),
-    ok.
 
 start_update(URL) ->
     case is_running(grisp_updater) of

--- a/src/grisp_connect_client.erl
+++ b/src/grisp_connect_client.erl
@@ -10,8 +10,10 @@
 -export([connect/0]).
 -export([is_connected/0]).
 -export([request/3]).
+-export([notify/3]).
 
 % Internal API
+-export([connected/0]).
 -export([disconnected/0]).
 -export([handle_message/1]).
 
@@ -48,6 +50,12 @@ is_connected() ->
 
 request(Method, Type, Params) ->
     gen_statem:call(?MODULE, {?FUNCTION_NAME, Method, Type, Params}).
+
+notify(Method, Type, Params) ->
+    gen_statem:cast(?MODULE, {?FUNCTION_NAME, Method, Type, Params}).
+
+connected() ->
+    gen_statem:cast(?MODULE, ?FUNCTION_NAME).
 
 disconnected() ->
     gen_statem:cast(?MODULE, ?FUNCTION_NAME).
@@ -97,16 +105,9 @@ connecting(enter, _OldState, _Data) ->
     {ok, Port} = application:get_env(grisp_connect, port),
     ?LOG_NOTICE(#{event => connecting, domain => Domain, port => Port}),
     grisp_connect_ws:connect(Domain, Port),
-    {keep_state_and_data, [{state_timeout, 0, wait}]};
-connecting(state_timeout, wait, Data) ->
-    case grisp_connect_ws:is_connected() of
-        true ->
-            ?LOG_NOTICE(#{event => connected}),
-            {next_state, connected, Data};
-        false ->
-            ?LOG_DEBUG(#{event => waiting_ws_connection}),
-            {keep_state_and_data, [{state_timeout, ?STD_TIMEOUT, wait}]}
-    end;
+    keep_state_and_data;
+connecting(cast, connected, Data) ->
+    {next_state, connected, Data};
 connecting(cast, disconnected, _Data) ->
     repeat_state_and_data;
 ?HANDLE_COMMON.
@@ -141,6 +142,10 @@ connected({call, From}, {request, Method, Type, Params},
     {keep_state,
      Data#data{requests = NewRequests},
      [{{timeout, ID}, request_timeout(), request}]};
+connected(cast, {notify, Method, Type, Params}, _Data) ->
+    Payload = grisp_connect_api:notify(Method, Type, Params),
+    grisp_connect_ws:send(Payload),
+    keep_state_and_data;
 ?HANDLE_COMMON.
 
 % Common event handling appended as last match case to each state_function

--- a/src/grisp_connect_client.erl
+++ b/src/grisp_connect_client.erl
@@ -121,15 +121,15 @@ connected(cast, disconnected, Data) ->
     grisp_connect_log_server:stop(),
     {next_state, waiting_ip, Data};
 connected(cast, {handle_message, Payload}, #data{requests = Requests} = Data) ->
-    Replies = grisp_connect_api:handle_msg(Payload),
+    Responses = grisp_connect_api:handle_msg(Payload),
     % A reduce operation is needed to support jsonrpc batch comunications
-    case Replies of
+    case Responses of
         [] ->
             keep_state_and_data;
-        [{request, Response}] -> % Response for a GRiSP.io request
+        [{send_response, Response}] -> % Response for a GRiSP.io request
             grisp_connect_ws:send(Response),
             keep_state_and_data;
-        [{response, ID, Response}] -> % GRiSP.io response
+        [{handle_response, ID, Response}] -> % handle a GRiSP.io response
             {OtherRequests, Actions} = dispatch_response(ID, Response, Requests),
             {keep_state, Data#data{requests = OtherRequests}, Actions}
     end;

--- a/src/grisp_connect_jsonrpc.erl
+++ b/src/grisp_connect_jsonrpc.erl
@@ -47,8 +47,8 @@ format_error({internal_error, method_not_found, ID}) ->
     {error, -32601, <<"Method not found">>, undefined, ID};
 format_error({internal_error, invalid_params, ID}) ->
     {error, -32602, <<"Invalid params">>, undefined, ID};
-format_error({internal_error, internal_error, ID}) ->
-    {error, -32603, <<"Internal error">>, undefined, ID}.
+format_error({internal_error, Reason, ID}) ->
+    {error, -32603, <<"Internal error">>, Reason, ID}.
 
 %--- Internal -----------------------------------------------------------------
 

--- a/src/grisp_connect_updater_progress.erl
+++ b/src/grisp_connect_updater_progress.erl
@@ -1,0 +1,70 @@
+-module(grisp_connect_updater_progress).
+-behaviour(grisp_updater_progress).
+
+%--- Includes ------------------------------------------------------------------
+
+-include_lib("kernel/include/logger.hrl").
+
+
+%--- Types ---------------------------------------------------------------------
+
+
+%--- Exports -------------------------------------------------------------------
+
+
+% Behaviour grisp_updater_progress callbacks
+-export([progress_init/1]).
+-export([progress_update/2]).
+-export([progress_warning/3]).
+-export([progress_error/3]).
+-export([progress_done/2]).
+
+
+%--- records -------------------------------------------------------------------
+
+-record(state, {
+    client :: pid(),
+    last_notification :: undefined | integer()
+}).
+
+
+%--- API Functions -------------------------------------------------------------
+
+
+%--- Behavior grisp_updater_progress Callback ----------------------------------
+
+progress_init(#{client := PID} = _Opts) ->
+    {ok, #state{
+        last_notification = erlang:system_time(millisecond),
+        client = PID
+    }}.
+
+progress_update(#state{last_notification = LastLog} = State, Stats) ->
+    case (erlang:system_time(millisecond) - LastLog) > 1000 of
+        false -> {ok, State};
+        true ->
+            % Recheck log level when there is another way to check the progress update
+            ?LOG_NOTICE("Update progress: ~b%", [progress_percent(Stats)]),
+            {ok, State#state{last_notification = erlang:system_time(millisecond)}}
+    end.
+
+progress_warning(State, Msg, Reason) ->
+    ?LOG_WARNING("Update warning; ~s: ~p", [Msg, Reason]),
+    {ok, State}.
+
+progress_error(#state{}, Stats, Reason) ->
+    ?LOG_ERROR("Update failed after ~b% : ~p",
+               [progress_percent(Stats), Reason]),
+    ok.
+
+progress_done(#state{}, _Stats) ->
+    ?LOG_NOTICE("Update done", []),
+    ok.
+
+
+%--- Internal Functions --------------------------------------------------------
+
+progress_percent(Stats) ->
+    #{data_total := Total, data_checked := Checked,
+      data_skipped := Skipped, data_written := Written} = Stats,
+    (Checked + Skipped + Written) * 100 div (Total * 2).

--- a/src/grisp_connect_updater_progress.erl
+++ b/src/grisp_connect_updater_progress.erl
@@ -41,10 +41,16 @@ progress_init(#{client := PID} = _Opts) ->
 
 progress_update(#state{last_notification = LastLog} = State, Stats) ->
     case (erlang:system_time(millisecond) - LastLog) > 1000 of
-        false -> {ok, State};
-        true ->
+        false -> 
+            {ok, State};
+        true  -> 
+            UpdatePercentage = progress_percent(Stats),
             % Recheck log level when there is another way to check the progress update
-            ?LOG_NOTICE("Update progress: ~b%", [progress_percent(Stats)]),
+            ?LOG_NOTICE("Update progress: ~b%", [UpdatePercentage]),
+            grisp_connect_client:request(
+                <<"notify">>,
+                <<"status_update">>, 
+                #{percentage => UpdatePercentage}),
             {ok, State#state{last_notification = erlang:system_time(millisecond)}}
     end.
 

--- a/src/grisp_connect_updater_progress.erl
+++ b/src/grisp_connect_updater_progress.erl
@@ -16,7 +16,7 @@
 -export([progress_init/1]).
 -export([progress_update/2]).
 -export([progress_warning/3]).
--export([progress_error/3]).
+-export([progress_error/4]).
 -export([progress_done/2]).
 
 
@@ -55,7 +55,7 @@ progress_update(#state{last_notification = LastLog} = State, Stats) ->
             {ok, State#state{last_notification = erlang:system_time(millisecond)}}
     end.
 
-progress_warning(State, Msg, Reason) ->
+progress_warning(State, Reason, Msg) ->
     ?LOG_WARNING("Update warning; ~s: ~p", [Msg, Reason]),
     grisp_connect_client:notify(
         <<"update">>,
@@ -65,7 +65,7 @@ progress_warning(State, Msg, Reason) ->
           message => Msg}),
     {ok, State}.
 
-progress_error(#state{}, Stats, Reason) ->
+progress_error(#state{}, Stats, Reason, Msg) ->
     UpdatePercentage = progress_percent(Stats),
     ?LOG_ERROR("Update failed after ~b% : ~p", [UpdatePercentage, Reason]),
     grisp_connect_client:notify(
@@ -73,6 +73,7 @@ progress_error(#state{}, Stats, Reason) ->
         <<"software_update_event">>,
         #{event      => error,
           reason     => Reason,
+          message    => Msg,
           percentage => UpdatePercentage}),
     ok.
 

--- a/src/grisp_connect_updater_progress.erl
+++ b/src/grisp_connect_updater_progress.erl
@@ -50,18 +50,30 @@ progress_update(#state{last_notification = LastLog} = State, Stats) ->
             grisp_connect_client:notify(
                 <<"update">>,
                 <<"software_update_event">>,
-                #{event => progress,
+                #{event      => progress,
                   percentage => UpdatePercentage}),
             {ok, State#state{last_notification = erlang:system_time(millisecond)}}
     end.
 
 progress_warning(State, Msg, Reason) ->
     ?LOG_WARNING("Update warning; ~s: ~p", [Msg, Reason]),
+    grisp_connect_client:notify(
+        <<"update">>,
+        <<"software_update_event">>,
+        #{event   => warning,
+          reason  => Reason,
+          message => Msg}),
     {ok, State}.
 
 progress_error(#state{}, Stats, Reason) ->
-    ?LOG_ERROR("Update failed after ~b% : ~p",
-               [progress_percent(Stats), Reason]),
+    UpdatePercentage = progress_percent(Stats),
+    ?LOG_ERROR("Update failed after ~b% : ~p", [UpdatePercentage, Reason]),
+    grisp_connect_client:notify(
+        <<"update">>,
+        <<"software_update_event">>,
+        #{event      => error,
+          reason     => Reason,
+          percentage => UpdatePercentage}),
     ok.
 
 progress_done(#state{}, _Stats) ->

--- a/test/grisp_connect_test_client.erl
+++ b/test/grisp_connect_test_client.erl
@@ -17,7 +17,7 @@ cert_dir() -> filename:join(code:lib_dir(grisp_connect, test), "certs").
 serial_number() -> <<"0000">>.
 
 wait_connection() ->
-    wait_connection(20).
+    wait_connection(2000).
 
 wait_connection(0) ->
     ct:pal("grisp_connect_ws state:~n~p~n", [sys:get_state(grisp_connect_ws)]),
@@ -26,12 +26,12 @@ wait_connection(N) ->
     case grisp_connect:is_connected() of
        true -> ok;
        false ->
-           ct:sleep(100),
+           ct:sleep(1),
            wait_connection(N - 1)
     end.
 
 wait_disconnection() ->
-    wait_disconnection(20).
+    wait_disconnection(2000).
 
 wait_disconnection(0) ->
     ct:pal("grisp_connect_ws state:~n~p~n", [sys:get_state(grisp_connect_ws)]),
@@ -39,7 +39,7 @@ wait_disconnection(0) ->
 wait_disconnection(N) ->
     case grisp_connect:is_connected() of
         true ->
-            ct:sleep(100),
+            ct:sleep(1),
             wait_disconnection(N - 1);
         false -> ok
     end.


### PR DESCRIPTION
## Tasks

- [x] Start_update request from seawater to the board
- [x] Notify the update progress to seawater from the board
- [x] Get partition state (of the board) endpoint 

---

## Get partition state local test


```erlang

%% NO UPDATE
(robot@grisp-001255)4> (robot@grisp-001255)4>  {ID, Encoded} = grisp_connect_api:request(<<"get">>, <<"partition_state">>, #{}).
{<<"-134217295">>,
 <<"{\"id\":\"-134217295\",\"params\":{\"type\":\"partition_state\"},\"method\":\"get\",\"jsonrpc\":\"2.0\"}">>}
 
(robot@grisp-001255)5> grisp_connect_api:handle_msg(Encoded).
[{send_response,<<"{\"id\":\"-134217295\",\"result\":{\"message\":\"No update pending, running old partition\",\"state\":\"old_no_update"...>>}]```

%% Update pending

Update done
 {ID55, Encoded55} = grisp_connect_api:request(<<"get">>, <<"partition_state">>, #{}).
{<<"-134216271">>,
 <<"{\"id\":\"-134216271\",\"params\":{\"type\":\"partition_state\"},\"method\":\"get\",\"jsonrpc\":\"2.0\"}">>}
(robot@grisp-001255)7> grisp_connect_api:handle_msg(Encoded55).
[{send_response,<<"{\"id\":\"-134216271\",\"result\":{\"message\":\"Reboot required to load new partition\",\"state\":\"old\",\"action_req"...>>}]

%% Remove SD & reboot

[{send_response,<<"{\"id\":\"-134217327\",\"result\":{\"message\":\"New partition booted, validation required\",\"state\":\"new\",\"action"...>>}]
(robot@grisp-001255)3> 

%% Validate :) 

{ID552, Encoded552} = grisp_connect_api:request(<<"post">>, <<"validate">>, #{}).
(robot@grisp-001255)4> grisp_connect_api:handle_msg(Encoded552).
[{send_response,<<"{\"id\":\"-134217311\",\"result\":\"ok\",\"jsonrpc\":\"2.0\"}">>}]

%% Check state
(robot@grisp-001255)5> {ID555, Encoded555} = grisp_connect_api:request(<<"get">>, <<"partition_state">>, #{}).
{<<"-134217295">>,
 <<"{\"id\":\"-134217295\",\"params\":{\"type\":\"partition_state\"},\"method\":\"get\",\"jsonrpc\":\"2.0\"}">>}

(robot@grisp-001255)6> grisp_connect_api:handle_msg(Encoded555).
[{send_response,<<"{\"id\":\"-134217295\",\"result\":{\"message\":\"No update pending, running old partition\",\"state\":\"old_no_update"...>>}]
```

----
## Improvement and other ideas

Here are some insights and suggestions I encountered while developing:

-  In [seawater config]( https://github.com/stritzinger/grisp_manager?tab=readme-ov-file#test-grisp_connect-with-seawater-local-dev-setup) highlight the different names of the cert (CA.pem & .pem files).
- When `rebar3 grisp pack` -  When packing a release, a green test instruction is displayed for non-rebar3 grisp-io plugin users. It could potentially distract users who don’t intend to perform the pack manually. Maybe we can write a warning.
- Integrating all docu related to setup local dev, maybe in confluence:
   -> 1) Ask for sys.config seawater env vars (api_key & password) 
   -> 2) [Seawater create an account and add a subscription](https://github.com/stritzinger/seawater?tab=readme-ov-file#how-to-add-a-subscription)
       --> 2,1) Explain subscription for testing in Seawater (and that you could use any token for subscription)
   -> 3) [Set up locally grisp_connect under grisp_project/_checkout/ with seawater](https://github.com/stritzinger/grisp_manager?tab=readme-ov-file#test-grisp_connect-with-seawater-local-dev-setup)
       --> 3,1) Specify in 0 step where, like create a grisp project, and under _checkouts of grisp board project clone the necessary repos (like grisp_connect, rebar3_grisp, rebar3_grisp_io, grisp_updater_grisp2, etc).
  
- Clarify persistent updates: Updates are stored persistently in memory, meaning users need to remove the SD card to boot from the partition. To avoid users restarting using removable.
- Future idea) `rebar3 configure --exisiting_project=<folder>` just for things like integrate network a posteriori or Wi-Fi.