### PR TITLE
Ensure certifi as default `tls_server_trusted_certs_cb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,21 @@ You can copy paste these settings. Here we both swap the default logger handler 
     ]}
 ].
 ```
+## Custom TLS options
 
+TLS settings are managed through the [grisp_cryptoauth](https://github.com/grisp/grisp_cryptoauth?tab=readme-ov-file#configuring-tls-options) TLS options.
+
+grisp_connect sets the folowing options as default values if no `tls_server_trusted_certs_cb` is setup.
+
+```erlang
+    % sys.config
+    [
+        ...
+        {grisp_cryptoauth, [
+            {tls_server_trusted_certs_cb, {certifi, cacerts, []}}
+        ]}
+    ]
+```
 ## Local Development
 
 Add an entry in your local hosts file so the domain www.seawater.local points

--- a/config/dev.config
+++ b/config/dev.config
@@ -1,5 +1,6 @@
 [
     {grisp_cryptoauth, [
+        {tls_server_trusted_certs_cb, []},
         {tls_server_trusted_certs, {priv, grisp_connect, "server"}}
     ]},
 

--- a/config/local.config
+++ b/config/local.config
@@ -5,7 +5,7 @@
 
     {grisp_cryptoauth, [
         {tls_server_trusted_certs, {priv, grisp_connect, "server"}},
-        {tls_client_truste_certs, {test, grisp_connect, "certs/CA.crt"}},
+        {tls_client_trusted_certs, {test, grisp_connect, "certs/CA.crt"}},
         {client_certs, {test, grisp_connect, "certs/client.crt"}},
         {client_key, {test, grisp_connect, "certs/client.key"}}
     ]},

--- a/config/local.config
+++ b/config/local.config
@@ -4,6 +4,7 @@
     ]},
 
     {grisp_cryptoauth, [
+        {tls_server_trusted_certs_cb, []},
         {tls_server_trusted_certs, {priv, grisp_connect, "server"}},
         {tls_client_trusted_certs, {test, grisp_connect, "certs/CA.crt"}},
         {client_certs, {test, grisp_connect, "certs/client.crt"}},

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,8 +1,4 @@
 [
-    {grisp_cryptoauth, [
-        {tls_server_trusted_certs_cb, {certifi, cacerts, []}}
-    ]},
-
     {grisp_connect, [
         {device_linking_token, <<"...">>}
     ]},

--- a/config/test.config
+++ b/config/test.config
@@ -4,6 +4,7 @@
     ]},
 
     {grisp_cryptoauth, [
+        {tls_server_trusted_certs_cb, []},
         {tls_client_trusted_certs, {test, grisp_connect, "certs/CA.crt"}},
         {client_certs, {test, grisp_connect, "certs/client.crt"}},
         {client_key, {test, grisp_connect, "certs/client.key"}},

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,8 @@
   {grisp, "~> 2.5"},
   {gun, "2.1.0"},
   jsx,
-  {grisp_cryptoauth, "~> 2.4"}
+  {grisp_cryptoauth, "~> 2.4"},
+  {certifi, "2.13.0"}
 ]}.
 
 {plugins, [rebar3_grisp, rebar3_ex_doc]}.
@@ -36,9 +37,8 @@
 
 {profiles, [
     {prod, [
-        {deps, [certifi]},
         {relx, [
-            {release, {grisp_connect, "0.1.0"}, [certifi, grisp_connect]},
+            {release, {grisp_connect, "0.1.0"}, [grisp_connect]},
             {sys_config, "config/sys.config"}
         ]}
     ]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,6 @@
 {"1.2.0",
-[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.13.0">>},1},
+[{<<"certifi">>,{pkg,<<"certifi">>,<<"2.13.0">>},0},
+ {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.13.0">>},1},
  {<<"grisp">>,{pkg,<<"grisp">>,<<"2.6.0">>},0},
  {<<"grisp_cryptoauth">>,{pkg,<<"grisp_cryptoauth">>,<<"2.4.0">>},0},
  {<<"gun">>,{pkg,<<"gun">>,<<"2.1.0">>},0},
@@ -7,6 +8,7 @@
  {<<"mapz">>,{pkg,<<"mapz">>,<<"2.4.0">>},1}]}.
 [
 {pkg_hash,[
+ {<<"certifi">>, <<"E52BE248590050B2DD33B0BB274B56678F9068E67805DCA8AA8B1CCDB016BBF6">>},
  {<<"cowlib">>, <<"DB8F7505D8332D98EF50A3EF34B34C1AFDDEC7506E4EE4DD4A3A266285D282CA">>},
  {<<"grisp">>, <<"9B6521555B15D54D232160B6AA843CB9D09555EF4EB9991C6C367A38D6DCAEA2">>},
  {<<"grisp_cryptoauth">>, <<"60773DFCB597893A1E98BFE2974A74C277D9FF6CE16BD918BFD906D43AAB86C0">>},
@@ -14,6 +16,7 @@
  {<<"jsx">>, <<"D12516BAA0BB23A59BB35DCCAF02A1BD08243FCBB9EFE24F2D9D056CCFF71268">>},
  {<<"mapz">>, <<"77A8E38B69BAB16C5D3EBD44E6C619F8AF1F1598B0CAAE301D266605A0865756">>}]},
 {pkg_hash_ext,[
+ {<<"certifi">>, <<"8F3D9533A0F06070AFDFD5D596B32E21C6580667A492891851B0E2737BC507A1">>},
  {<<"cowlib">>, <<"E1E1284DC3FC030A64B1AD0D8382AE7E99DA46C3246B815318A4B848873800A4">>},
  {<<"grisp">>, <<"71E9DDEF2236F731C0F9998E07AB9B4F0F657C774552555B7572EA9F47711405">>},
  {<<"grisp_cryptoauth">>, <<"D9BD51BC877986404FCF6DB1E3DF196C919BD6F55398FA03262D1C4323410AB9">>},

--- a/src/grisp_connect.app.src
+++ b/src/grisp_connect.app.src
@@ -10,7 +10,8 @@
         grisp,
         grisp_cryptoauth,
         gun,
-        jsx
+        jsx,
+        certifi
     ]},
     {optional_applications, [
         grisp_updater_grisp2

--- a/src/grisp_connect_app.erl
+++ b/src/grisp_connect_app.erl
@@ -18,7 +18,21 @@
 
 start(_StartType, _StartArgs) ->
     logger:add_handlers(grisp_connect),
+    ensure_trusted_server_certs_are_set(),
     grisp_connect_sup:start_link().
 
 stop(_State) ->
     ok.
+
+%--- Internal Functions --------------------------------------------------------
+
+ensure_trusted_server_certs_are_set() ->
+    case application:get_env(grisp_cryptoauth, tls_server_trusted_certs_cb) of
+        {ok, _} ->
+            ok;
+        undefined ->
+            Certifi = {certifi, cacerts, []},
+            application:set_env(grisp_cryptoauth,
+                                tls_server_trusted_certs_cb,
+                                Certifi)
+    end.


### PR DESCRIPTION
`tls_server_trusted_certs_cb` is required by `grisp_cryptoauth`

- Define certifi:cacerts on boot if no option is defined by the user
- Document this behaviour and point to grisp_cryptoauth doc for reference
- Set empty lists in the other configurations to avoid certifi outside the prod profile
- Restored certifi as fixed dependency