### PR TITLE
Add grisp.io custom protocol version header

### DIFF
--- a/config/dev.config
+++ b/config/dev.config
@@ -1,6 +1,5 @@
 [
     {grisp_cryptoauth, [
-        {tls_server_trusted_certs_cb, []},
         {tls_server_trusted_certs, {priv, grisp_connect, "server"}}
     ]},
 

--- a/config/local.config
+++ b/config/local.config
@@ -4,7 +4,6 @@
     ]},
 
     {grisp_cryptoauth, [
-        {tls_server_trusted_certs_cb, []},
         {tls_server_trusted_certs, {priv, grisp_connect, "server"}},
         {tls_client_trusted_certs, {test, grisp_connect, "certs/CA.crt"}},
         {client_certs, {test, grisp_connect, "certs/client.crt"}},

--- a/config/test.config
+++ b/config/test.config
@@ -4,7 +4,6 @@
     ]},
 
     {grisp_cryptoauth, [
-        {tls_server_trusted_certs_cb, []},
         {tls_client_trusted_certs, {test, grisp_connect, "certs/CA.crt"}},
         {client_certs, {test, grisp_connect, "certs/client.crt"}},
         {client_key, {test, grisp_connect, "certs/client.key"}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -6,7 +6,7 @@
  {<<"gun">>,{pkg,<<"gun">>,<<"2.1.0">>},1},
  {<<"jarl">>,
   {git,"https://github.com/grisp/jarl.git",
-       {ref,"b33ef85c206723cc3f85cd8c3ec95062436ec44b"}},
+       {ref,"24d53cc7b521b126588be1f36afecd1d4eb59db3"}},
   0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"3.1.0">>},0},
  {<<"mapz">>,{pkg,<<"mapz">>,<<"2.4.0">>},1}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -6,7 +6,7 @@
  {<<"gun">>,{pkg,<<"gun">>,<<"2.1.0">>},1},
  {<<"jarl">>,
   {git,"https://github.com/grisp/jarl.git",
-       {ref,"10085d38df19c67664d33ef61f515c92a8b0de56"}},
+       {ref,"b33ef85c206723cc3f85cd8c3ec95062436ec44b"}},
   0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"3.1.0">>},0},
  {<<"mapz">>,{pkg,<<"mapz">>,<<"2.4.0">>},1}]}.

--- a/src/grisp_connect.app.src
+++ b/src/grisp_connect.app.src
@@ -25,6 +25,7 @@
         {ws_path, "/grisp-connect/ws"},
         {ws_request_timeout, 5_000},
         {ws_ping_timeout, 60_000},
+        {ws_max_retries, infinity},
         {logs_interval, 2_000},
         {logs_batch_size, 100},
         {logger, [

--- a/src/grisp_connect_api.erl
+++ b/src/grisp_connect_api.erl
@@ -15,6 +15,7 @@
 % @doc Handles requests and notifications from grisp.io.
 -spec handle_msg(Msg) ->
     ok | {reply, Result :: term(), ReqRef :: binary() | integer()}
+    | {error, Code :: integer() | atom(), Message :: binary() | undefined, ErData :: term(), ReqRef :: binary() | integer()}
   when Msg :: {request, Method :: jarl:method(), Params :: map() | list(), ReqRef :: binary() | integer()}
             | {notification, jarl:method(), Params :: map() | list()}.
 handle_msg({notification, M, Params}) ->

--- a/test/grisp_connect_api_SUITE.erl
+++ b/test/grisp_connect_api_SUITE.erl
@@ -66,7 +66,7 @@ bad_client_version_test(_) ->
     CertDir = cert_dir(),
     Apps = grisp_connect_test_server:start(#{
         cert_dir => CertDir,
-        expected_grisp_io_version => <<"42.0">>}),
+        expected_protocol => <<"grisp-io-v42">>}),
     try
         {ok, _} = application:ensure_all_started(grisp_emulation),
         application:load(grisp_connect),
@@ -88,14 +88,15 @@ bad_server_version_test(_) ->
     CertDir = cert_dir(),
     Apps = grisp_connect_test_server:start(#{
         cert_dir => CertDir,
-        selected_grisp_io_version => <<"42.0">>}),
+        selected_protocol => <<"grisp-io-v42">>}),
     try
         {ok, _} = application:ensure_all_started(grisp_emulation),
         application:load(grisp_connect),
         application:set_env(grisp_connect, ws_max_retries, 2),
         {ok, _} = application:ensure_all_started(grisp_connect),
         try
-            ?assertMatch({error, {unsupported_grisp_io_version, _}}, wait_connection())
+            % There is no way to know the reason why gun closed the connection
+            ?assertMatch({error, {closed, _}}, wait_connection())
         after
             ok = application:stop(grisp_connect)
         end

--- a/test/grisp_connect_log_SUITE.erl
+++ b/test/grisp_connect_log_SUITE.erl
@@ -28,7 +28,7 @@ all() ->
 
 init_per_suite(Config) ->
     CertDir = cert_dir(),
-    Apps = grisp_connect_test_server:start(CertDir),
+    Apps = grisp_connect_test_server:start(#{cert_dir => CertDir}),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->

--- a/test/grisp_connect_reconnect_SUITE.erl
+++ b/test/grisp_connect_reconnect_SUITE.erl
@@ -90,5 +90,5 @@ reconnect_on_closed_frame_test(_) ->
 connection_gun_pid() ->
     {_, {data, _, _, _, _, ConnPid, _, _, _, _}} = sys:get_state(grisp_connect_client),
     % Depends on the internal state of jarl_connection
-    {_, {data, _, _, _, _, _, _, _, _, _, _, _, GunPid, _, _, _}} = sys:get_state(ConnPid),
+    {_, {data, _, _, _, _, _, _, _, _, _, _, _, _, GunPid, _, _, _}} = sys:get_state(ConnPid),
     GunPid.

--- a/test/grisp_connect_reconnect_SUITE.erl
+++ b/test/grisp_connect_reconnect_SUITE.erl
@@ -36,7 +36,7 @@ end_per_suite(Config) ->
     [?assertEqual(ok, application:stop(App)) || App <- ?config(apps, Config)].
 
 init_per_testcase(_, Config) ->
-    start_cowboy(cert_dir()),
+    start_cowboy(#{cert_dir => cert_dir()}),
     {ok, _} = application:ensure_all_started(grisp_emulation),
     application:set_env(grisp_connect, ws_ping_timeout, 120_000),
     {ok, _} = application:ensure_all_started(grisp_connect),
@@ -62,7 +62,7 @@ reconnect_on_disconnection_test(Config) ->
     ?assertMatch(ok, wait_connection()),
     stop_cowboy(),
     ?assertMatch(ok, wait_disconnection()),
-    start_cowboy(cert_dir()),
+    start_cowboy(#{cert_dir => cert_dir()}),
     ?assertMatch(ok, wait_connection(1200)),
     Config.
 
@@ -88,7 +88,7 @@ reconnect_on_closed_frame_test(_) ->
 %--- Internal Functions --------------------------------------------------------
 
 connection_gun_pid() ->
-    {_, {data, _, _, _, _, ConnPid, _}} = sys:get_state(grisp_connect_client),
+    {_, {data, _, _, _, _, ConnPid, _, _, _, _}} = sys:get_state(grisp_connect_client),
     % Depends on the internal state of jarl_connection
     {_, {data, _, _, _, _, _, _, _, _, _, _, _, GunPid, _, _, _}} = sys:get_state(ConnPid),
     GunPid.

--- a/test/grisp_connect_test_client.erl
+++ b/test/grisp_connect_test_client.erl
@@ -17,17 +17,12 @@ cert_dir() -> filename:join([code:lib_dir(grisp_connect), "test", "certs"]).
 serial_number() -> <<"0000">>.
 
 wait_connection() ->
-    wait_connection(30_000).
+    grisp_connect_client:wait_connected(30_000).
 
 wait_connection(0) ->
     {error, timeout};
-wait_connection(N) ->
-    case grisp_connect:is_connected() of
-       true -> ok;
-       false ->
-           ct:sleep(1),
-           wait_connection(N - 1)
-    end.
+wait_connection(Timeout) ->
+    grisp_connect_client:wait_connected(Timeout).
 
 wait_disconnection() ->
     wait_disconnection(30_000).

--- a/test/grisp_connect_test_server.erl
+++ b/test/grisp_connect_test_server.erl
@@ -200,17 +200,17 @@ wait_disconnection() ->
 %--- Websocket Callbacks -------------------------------------------------------
 
 init(Req, Opts) ->
-    ExpVer = maps:get(expected_grisp_io_version, Opts, <<"1.0">>),
-    SelVer = maps:get(selected_grisp_io_version, Opts, <<"1.0">>),
-    case cowboy_req:header(<<"x-grisp-io-version">>, Req) of
+    ExpVer = maps:get(expected_protocol, Opts, <<"grisp-io-v1">>),
+    SelVer = maps:get(selected_protocol, Opts, <<"grisp-io-v1">>),
+    case cowboy_req:header(<<"sec-websocket-protocol">>, Req) of
         undefined ->
-            Req2 = cowboy_req:reply(400, #{}, <<"No Grisp.io version specified">>, Req),
+            Req2 = cowboy_req:reply(400, #{}, <<"No protocol specified">>, Req),
             {ok, Req2, Opts};
         ExpVer ->
-            Req2 = cowboy_req:set_resp_header(<<"x-grisp-io-version">>, SelVer, Req),
+            Req2 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, SelVer, Req),
             {cowboy_websocket, Req2, Opts};
         _ ->
-            Req2 = cowboy_req:reply(400, #{}, <<"Unsupported Grisp.io Version">>, Req),
+            Req2 = cowboy_req:reply(400, #{}, <<"Unsupported Protocol">>, Req),
             {ok, Req2, Opts}
     end.
 


### PR DESCRIPTION
Add grisp.io protocol versioning
 - Remove invalid configuration.
 - Fix dialyzer spec.
 - Add option to limit the number of connection retries, mostly for
   testing use-cases that will always fail to connect.
 - Implemente wait_connected in the client to support reaching maximum
   connection retries and get the last known error.