### PR TITLE
Remove prepended warning in JSON-incompatible log reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Add log event metadata instead of prepending "[JSON incompatible term]" to
+log string data.
+
 ## [2.0.0] - 2025-02-26
 
 ### Changed

--- a/src/grisp_connect_log.erl
+++ b/src/grisp_connect_log.erl
@@ -58,9 +58,10 @@ jsonify_msg(#{msg := {report, Report}} = Event) ->
             maps:put(msg, Report, Event);
         false ->
             String = unicode:characters_to_binary(
-                       io_lib:format("[JSON incompatible term]~n~tp", [Report])
-                      ),
-            maps:put(msg, String, Event)
+                       io_lib:format("~tp", [Report])),
+            Meta = maps:get(meta, Event, #{}),
+            Event2 = Event#{meta => Meta#{incompatible_term => true}},
+            maps:put(msg, String, Event2)
     end;
 jsonify_msg(#{msg := {FormatString, Term}} = Event) ->
     %FIXME: scan format and ensure unicode encoding

--- a/test/grisp_connect_log_SUITE.erl
+++ b/test/grisp_connect_log_SUITE.erl
@@ -168,7 +168,7 @@ structured_logs_test(_) ->
              #{event => #{<<"errör"/utf8>> => false}},
              #{event => 1234},
              #{event => 0.1},
-             <<"[JSON incompatible term]\n#{event => {äh,bäh}}"/utf8>>],
+             <<"#{event => {äh,bäh}}"/utf8>>],
     % Ensure there is at least one log entry, so LastSeq is defined
     grisp_connect:log(error, ["dummy"]),
     LastSeq = log_reset(),


### PR DESCRIPTION
Remove hard-coded warning from JSON-incompatible log reports sent to grisp.io.
Add metadata instead so grisp.io could show a warning anyway if required.