### PR TITLE
Make NTP client more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ In such case the state machine that maintains the connection can be started manu
 ### `ntp`
 
 An optional NTP client can be started using option `{ntp, true}`.
-Such client is disabled by default (`{ntp, false}`), and is not required to authenticate with GRiSP.io. The client sets the time using `grisp_rtems:clock_set/1`
+Such client is disabled by default (`{ntp, false}`), and is not required to
+authenticate with GRiSP.io. The client sets the time using
+`grisp_rtems:clock_set/1`.
+The default NTP servers to use can be overridden by setting the `grisp_connect`
+option: `{ntp_servers, ["ntp1.server.foo", "ntp2.server.foo"]}`. For every NTP
+requests, a server address will be picked randomly from the list.
 
 ### `ws_request_timeout`
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ authenticate with GRiSP.io. The client sets the time using
 The default NTP servers to use can be overridden by setting the `grisp_connect`
 option: `{ntp_servers, ["ntp1.server.foo", "ntp2.server.foo"]}`. For every NTP
 requests, a server address will be picked randomly from the list.
+The default refresh period in seconds can be overridden by setting the
+`grisp_connect` option: `{ntp_refresh_period, 1024}`.
 
 ### `ws_request_timeout`
 

--- a/src/grisp_connect.app.src
+++ b/src/grisp_connect.app.src
@@ -21,6 +21,7 @@
         {port, 443},
         {connect, true}, % keeps a constant connection with grisp.io
         {ntp, false}, % if set to true, starts the NTP client
+        {ntp_servers, ["0.europe.pool.ntp.org"]},
         {ws_transport, tls},
         {ws_path, "/grisp-connect/ws"},
         {ws_request_timeout, 5_000},

--- a/src/grisp_connect.app.src
+++ b/src/grisp_connect.app.src
@@ -22,6 +22,7 @@
         {connect, true}, % keeps a constant connection with grisp.io
         {ntp, false}, % if set to true, starts the NTP client
         {ntp_servers, ["0.europe.pool.ntp.org"]},
+        {ntp_refresh_period, 512}, % in seconds
         {ws_transport, tls},
         {ws_path, "/grisp-connect/ws"},
         {ws_request_timeout, 5_000},

--- a/src/grisp_connect_ntp.erl
+++ b/src/grisp_connect_ntp.erl
@@ -85,7 +85,8 @@ refresh_time(state_timeout, request_time,
             ?LOG_NOTICE("GRiSP clock set from NTP to ~s",
                         [format_datetime(Datetime)]),
             {next_state, ready, Data#data{retry_count = 0}}
-    end.
+    end;
+?HANDLE_COMMON.
 
 ready(enter, _OldState, _Data) ->
     Period = refresh_period(),

--- a/src/grisp_connect_utils.erl
+++ b/src/grisp_connect_utils.erl
@@ -1,0 +1,65 @@
+-module(grisp_connect_utils).
+
+
+%--- Exports -------------------------------------------------------------------
+
+% API functions
+-export([retry_delay/1]).
+-export([check_inet_ipv4/0]).
+
+
+%--- API Functions -------------------------------------------------------------
+
+check_inet_ipv4() ->
+    case get_ip_of_valid_interfaces() of
+        {ok, {IP1, _, _, _} = IP} when IP1 =/= 127 -> {ok, IP};
+        _ -> invalid
+    end.
+
+
+%--- Internal Functions --------------------------------------------------------
+
+retry_delay(0) ->
+    0;
+retry_delay(RetryCount) ->
+    %% Calculate the connection delay in milliseconds with exponential backoff.
+    %% The delay is selected randomly between `1000' and
+    %% `2 ^ RETRY_COUNT - 1000' with a maximum value of `64000'.
+    %% Loosely inspired by https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+    MinDelay = 1000,
+    MaxDelay = 64000,
+    MaxRandomDelay = min(MaxDelay, (1 bsl RetryCount) * 1000) - MinDelay,
+    MinDelay + rand:uniform(MaxRandomDelay).
+
+get_ipv4_from_opts([]) ->
+    undefined;
+get_ipv4_from_opts([{addr, {_1, _2, _3, _4}} | _]) ->
+    {ok, {_1, _2, _3, _4}};
+get_ipv4_from_opts([_ | TL]) ->
+    case get_ipv4_from_opts(TL) of
+        {ok, _IP} = Result -> Result;
+        Other -> Other
+    end.
+
+has_ipv4(Opts) ->
+    get_ipv4_from_opts(Opts) =/= undefined.
+
+flags_are_ok(Flags) ->
+    lists:member(up, Flags) and
+        lists:member(running, Flags) and
+        not lists:member(loopback, Flags).
+
+get_valid_interfaces() ->
+    case inet:getifaddrs() of
+        {error, _Reason} = Error -> Error;
+        {ok, Interfaces} ->
+            {ok, [Opts || {_Name, [{flags, Flags} | Opts]} <- Interfaces,
+                          flags_are_ok(Flags), has_ipv4(Opts)]}
+    end.
+
+get_ip_of_valid_interfaces() ->
+    case get_valid_interfaces() of
+        {error, _Reason} = Error -> Error;
+        {ok, [Opts | _]} -> get_ipv4_from_opts(Opts);
+        _ -> undefined
+    end.


### PR DESCRIPTION
The NTP client is now a state machine, use exponencial backoff, reuse the same IP check function than the client and periodically refresh the time.

One of the question is if refreshing the time every 256 seconds is good, a real NTP client would do some smart calculation instead of just setting the time to the new one...