### PR TITLE
Add log formatter with option to only log report description

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ You can copy paste these settings:
 ].
 ```
 
+To simplify the log on the device while still sending full log reports to
+griso.io, use grisp_connect_log log formatter with single-line in the default
+log handler:
+
+```
+            {handler, default, logger_std_h, #{
+                level => notice,
+                formatter => {grisp_connect_log, #{
+                    legacy_header => false,
+                    single_line => true,
+                    description_only => true
+                }},
+                filter_default => log,
+                filters => [
+                    % Filter out supervisor progress reports so TLS certificates
+                    % are not swamping the console if the level is set to info...
+                    {disable_progress, {fun logger_filters:progress/2, stop}}
+                ]
+            }}
+```
+
 ## Development
 
 ### Local Development


### PR DESCRIPTION
Add a log formatter that has an option to log only the report description.
This can make the log cleaner on the device console when enabling single-line logging.

Depends on [PR #60](https://github.com/grisp/grisp_connect/pull/60)

Tested with jarl [PR #3](https://github.com/grisp/jarl/pull/3) in `_checkouts`

To use it with single-line login:
```
    {kernel, [
        {logger_level, debug},
        {logger, [
            {handler, default, logger_std_h, #{
                level => debug,
                formatter => {grisp_connect_log, #{
                    legacy_header => false,
                    single_line => true,
                    description_only => true
                }},
                filter_default => log,
                filters => [
                    % Filter out supervisor progress reports so TLS certificates
                    % are not swamping the console if level is set to info...
                    {disable_progress, {fun logger_filters:progress/2, stop}}
                ]
            }},
            {handler, grisp_connect_log_handler,  grisp_connect_logger_bin, #{
                level => info,
                filter_default => log,
                formatter => {grisp_connect_logger_bin, #{}},
                filters => [
                    % Filter out supervisor progress reports so TLS certificates
                    % are not swamping grisp.io if level is set to info...
                    {disable_progress, {fun logger_filters:progress/2, stop}}
                ]
             }
            }
        ]}
    ]}
```